### PR TITLE
Modified csproj to net6.0, from net5.0

### DIFF
--- a/snallWeeks-lab-firstDotNetApp.csproj
+++ b/snallWeeks-lab-firstDotNetApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>snallWeeks_lab_firstDotNetApp</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
I just couldn't get any old SDK or runtimes to work on Ubuntu, and it seemed easier to just modify the runtime of the project!